### PR TITLE
Add privacy-aware request metadata to detector reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -314,6 +314,28 @@ juice 不能单独让综合检测通过。即使 juice 看起来像 Sol，也必
 
 ## key 和报告安全
 
+### 请求级详细信息与隐私配置
+
+图形界面的“报告包含信息”区域可以逐项控制请求元数据。默认记录 Request ID、UTC 开始/完成时间、耗时、HTTP 状态、服务端 `usage` token 和响应字节数；服务端 IP、发起端出口 IP 默认关闭。
+
+Request ID 同时保留三层定位信息：
+
+- `correlation_id`：检测器为每一次网络尝试生成，并通过 `X-Client-Request-ID` 请求头发送；即使超时或服务端没有返回 ID，也能把控制台日志、重试和 JSON 条目对应起来；
+- `server_request_id`：从 `x-request-id`、`request-id`、`openai-request-id`、`x-correlation-id`、`traceparent`、`cf-ray` 等响应头中提取，并记录来源头；
+- `response_id`：Responses API JSON 返回的 `id`。它经常是向 API 提供方进一步定位具体请求时最直接的标识。
+
+发生重试时，每一次失败的网络尝试也会在 `transport_errors[].request_metadata` 中保留自己的关联 ID、时间和可用响应信息，不会只留下最终成功请求。
+
+token 统计优先使用服务端 `usage`，兼容 `input_tokens`/`output_tokens` 和 `prompt_tokens`/`completion_tokens` 命名。只有主动勾选“高级：无 usage 时估算 token”或使用 `--estimate-tokens` 时，才会按可见 Unicode 字符数进行粗略估算；报告会以 `source=estimated`、估算方法和警告明确标记，不能将它视为计费 token。
+
+IP 字段的含义和限制：
+
+- `server_ips` 是目标 API 主机名的 DNS 解析结果。启用 HTTP 代理时，它不是代理连接的 peer IP；报告会保留这一限制说明；
+- `client_egress_ip` 通过配置的 IP echo 地址查询。该查询使用 Python/系统代理设置，因此配置代理时得到的是代理实际出口 IP，而不是本机网卡地址。开启它会向查询服务额外发送一次请求；检测器会缓存结果，避免每个检测请求都重复查询；
+- 可用 `--client-ip-lookup-url` 换成自建或组织内部的 IP echo 服务。默认地址只会在显式启用发起端 IP 时访问。
+
+命令行对应选项包括 `--include-server-ip`、`--include-client-ip`、`--client-ip-lookup-url`、`--estimate-tokens`，以及 `--omit-request-id`、`--omit-timestamps`、`--omit-duration`、`--omit-http-status`、`--omit-token-usage`、`--omit-response-size`。
+
 报告不会保存：
 
 - API key；

--- a/gpt56_gui.py
+++ b/gpt56_gui.py
@@ -49,6 +49,18 @@ class DetectorGUI:
         self.candidate_model = tk.StringVar(value="gpt-5.6-sol")
         self.candidate_key = tk.StringVar()
         self.same_key = tk.BooleanVar(value=False)
+        self.include_request_id = tk.BooleanVar(value=True)
+        self.include_timestamps = tk.BooleanVar(value=True)
+        self.include_duration = tk.BooleanVar(value=True)
+        self.include_http_status = tk.BooleanVar(value=True)
+        self.include_token_usage = tk.BooleanVar(value=True)
+        self.include_response_size = tk.BooleanVar(value=True)
+        self.include_server_ip = tk.BooleanVar(value=False)
+        self.include_client_ip = tk.BooleanVar(value=False)
+        self.estimate_tokens = tk.BooleanVar(value=False)
+        self.client_ip_lookup_url = tk.StringVar(
+            value="https://api64.ipify.org?format=json"
+        )
         self.min_interval = tk.StringVar(value="150")
         self.max_interval = tk.StringVar(value="210")
         self.single_workers = tk.StringVar(value="8")
@@ -224,6 +236,42 @@ class DetectorGUI:
         )
         self.workers_spinbox.pack(anchor="w", pady=(4, 0))
 
+        metadata = ttk.LabelFrame(parent, text="报告包含信息", padding=10)
+        metadata.pack(fill="x", pady=(0, 10))
+        ttk.Label(
+            metadata,
+            text="默认字段可用于精确定位每次请求；IP 默认关闭。",
+            style="Detail.TLabel",
+            wraplength=315,
+        ).pack(anchor="w", pady=(0, 5))
+        default_fields = (
+            ("Request ID（客户端关联 ID + 服务端 ID）", self.include_request_id),
+            ("时间", self.include_timestamps),
+            ("耗时", self.include_duration),
+            ("HTTP 状态", self.include_http_status),
+            ("服务端 usage token", self.include_token_usage),
+            ("响应大小", self.include_response_size),
+        )
+        for label, variable in default_fields:
+            ttk.Checkbutton(metadata, text=label, variable=variable).pack(anchor="w")
+        ttk.Separator(metadata).pack(fill="x", pady=5)
+        ttk.Checkbutton(
+            metadata,
+            text="服务端 IP（目标 DNS 结果；代理时不是代理 peer IP）",
+            variable=self.include_server_ip,
+        ).pack(anchor="w")
+        ttk.Checkbutton(
+            metadata,
+            text="发起端真实出口 IP（通过代理感知的 IP 查询）",
+            variable=self.include_client_ip,
+        ).pack(anchor="w")
+        self._entry(metadata, "出口 IP 查询地址", self.client_ip_lookup_url)
+        ttk.Checkbutton(
+            metadata,
+            text="高级：无 usage 时估算 token（不一定准确）",
+            variable=self.estimate_tokens,
+        ).pack(anchor="w")
+
         output = ttk.LabelFrame(parent, text="报告", padding=10)
         output.pack(fill="x", pady=(0, 12))
         output_row = ttk.Frame(output)
@@ -362,6 +410,21 @@ class DetectorGUI:
         script = APP_DIR / ("gpt56_reasoning_monitor.py" if continuous else "gpt56_reasoning_probe.py")
         gap_min, gap_max = ("2", "5") if continuous else ("0", "0")
         command = [sys.executable, str(script), "--candidate-base-url", candidate_url, "--candidate-model", self.candidate_model.get().strip() or "gpt-5.6-sol", "--candidate-retries", "2", "--candidate-min-gap", gap_min, "--candidate-max-gap", gap_max, "--output", str(output)]
+        metadata_flags = (
+            ("--omit-request-id", not self.include_request_id.get()),
+            ("--omit-timestamps", not self.include_timestamps.get()),
+            ("--omit-duration", not self.include_duration.get()),
+            ("--omit-http-status", not self.include_http_status.get()),
+            ("--omit-token-usage", not self.include_token_usage.get()),
+            ("--omit-response-size", not self.include_response_size.get()),
+            ("--include-server-ip", self.include_server_ip.get()),
+            ("--include-client-ip", self.include_client_ip.get()),
+            ("--estimate-tokens", self.estimate_tokens.get()),
+        )
+        for flag, enabled in metadata_flags:
+            if enabled:
+                command.append(flag)
+        command.extend(["--client-ip-lookup-url", self.client_ip_lookup_url.get().strip()])
         if continuous:
             minimum = int(self.min_interval.get())
             maximum = int(self.max_interval.get())

--- a/gpt56_juice_probe.py
+++ b/gpt56_juice_probe.py
@@ -296,12 +296,16 @@ def run_juice_request(
         except Exception as exc:
             last_error = exc
             status = getattr(exc, "status", None)
-            elapsed_ms = getattr(exc, "elapsed_ms", None)
-            transport_errors.append({
-                "http_status": status,
-                "elapsed_ms": elapsed_ms,
+            request_metadata = getattr(exc, "metadata", {})
+            error_event = {
                 "error_type": type(exc).__name__,
-            })
+                "request_metadata": request_metadata,
+            }
+            if "http_status" in request_metadata:
+                error_event["http_status"] = request_metadata["http_status"]
+            if "elapsed_ms" in request_metadata:
+                error_event["elapsed_ms"] = request_metadata["elapsed_ms"]
+            transport_errors.append(error_event)
             transient = status is None or status in TRANSIENT_HTTP_STATUSES
             if transport_attempt >= max_transport_attempts or not transient:
                 break
@@ -320,11 +324,10 @@ def run_juice_request(
         "answer_kind": "error",
         "normalized_value": None,
         "matched_models": [],
-        "http_status": getattr(last_error, "status", None),
-        "elapsed_ms": getattr(last_error, "elapsed_ms", None),
         "transport_attempts": transport_attempt,
         "transport_errors": transport_errors,
         "error_type": type(last_error).__name__,
+        **getattr(last_error, "metadata", {}),
     }
 
 
@@ -385,12 +388,16 @@ def run_output_literal_control(
         except Exception as exc:
             last_error = exc
             status = getattr(exc, "status", None)
-            elapsed_ms = getattr(exc, "elapsed_ms", None)
-            transport_errors.append({
-                "http_status": status,
-                "elapsed_ms": elapsed_ms,
+            request_metadata = getattr(exc, "metadata", {})
+            error_event = {
                 "error_type": type(exc).__name__,
-            })
+                "request_metadata": request_metadata,
+            }
+            if "http_status" in request_metadata:
+                error_event["http_status"] = request_metadata["http_status"]
+            if "elapsed_ms" in request_metadata:
+                error_event["elapsed_ms"] = request_metadata["elapsed_ms"]
+            transport_errors.append(error_event)
             transient = status is None or status in TRANSIENT_HTTP_STATUSES
             if transport_attempt >= max_transport_attempts or not transient:
                 break
@@ -415,11 +422,10 @@ def run_output_literal_control(
         "observed_text": None,
         "answer_kind": "error",
         "normalized_value": None,
-        "http_status": getattr(last_error, "status", None),
-        "elapsed_ms": getattr(last_error, "elapsed_ms", None),
         "transport_attempts": transport_attempt,
         "transport_errors": transport_errors,
         "error_type": type(last_error).__name__,
+        **getattr(last_error, "metadata", {}),
     }
 
 

--- a/gpt56_reasoning_monitor.py
+++ b/gpt56_reasoning_monitor.py
@@ -15,6 +15,12 @@ import time
 from typing import Any
 
 from gpt56_report_html import write_report_html
+from gpt56_request_metadata import (
+    add_metadata_arguments,
+    format_attempt_logs,
+    format_metadata_log,
+    metadata_options_from_args,
+)
 
 from gpt56_juice_probe import (
     AUXILIARY_EFFORTS,
@@ -130,11 +136,15 @@ def call_and_score(
             }
         except ProbeError as exc:
             last_error = exc
-            transport_errors.append({
-                "http_status": exc.status,
-                "elapsed_ms": exc.elapsed_ms,
+            error_event = {
                 "error": redact(str(exc)),
-            })
+                "request_metadata": exc.metadata,
+            }
+            if "http_status" in exc.metadata:
+                error_event["http_status"] = exc.metadata["http_status"]
+            if "elapsed_ms" in exc.metadata:
+                error_event["elapsed_ms"] = exc.metadata["elapsed_ms"]
+            transport_errors.append(error_event)
             transient = exc.status is None or exc.status in TRANSIENT_HTTP_STATUSES
             if transport_attempt >= max_transport_attempts or not transient:
                 break
@@ -146,11 +156,10 @@ def call_and_score(
         "status": "error",
         "exact": False,
         "plaintext_leak": False,
-        "http_status": last_error.status,
-        "elapsed_ms": last_error.elapsed_ms,
         "transport_attempts": transport_attempt,
         "transport_errors": transport_errors,
         "error": redact(str(last_error)),
+        **last_error.metadata,
     }
 
 def seed_payload(model: str, prompt: str) -> dict[str, Any]:
@@ -185,6 +194,7 @@ def run_one_challenge(
             "task": task,
             "http_status": exc.status,
             "error": redact(str(exc)),
+            "request_metadata": exc.metadata,
         }
 
     output = seed.get("output")
@@ -576,7 +586,9 @@ def parse_args() -> argparse.Namespace:
         help="skip trusted encrypted-state challenges and continuously probe Juice only",
     )
     parser.add_argument("--output", type=Path, default=Path("gpt56-monitor-report.json"))
+    add_metadata_arguments(parser)
     args = parser.parse_args()
+    args.metadata_options = metadata_options_from_args(args)
     if args.min_interval < 1 or args.max_interval < args.min_interval:
         parser.error("intervals must satisfy 1 <= min <= max")
     if not args.juice_only and not args.trusted_base_url:
@@ -702,6 +714,15 @@ def print_monitor_status(
         f"{output_control['expected_counts']['32']}）"
     )
     print(f"线路情况：{network['title_cn']}（{network['detail_cn']}）")
+    if juice_observation is not None:
+        suffix = format_metadata_log(juice_observation)
+        if suffix:
+            print(f"Juice request{suffix}")
+    controls = report.get("output_literal_control_observations", [])
+    if controls:
+        suffix = format_metadata_log(controls[-1])
+        if suffix:
+            print(f"Output control request{suffix}")
 
     current = None if juice_only else trial or candidate_attempt
     if current is not None:
@@ -717,6 +738,14 @@ def print_monitor_status(
             f"去掉编号{'答对' if candidate['without_ids'].get('exact') else '未答对'}，"
             f"异常 {abnormal_now}，失败 {failed}，重试 {retry_events}"
         )
+        for variant, result in candidate.items():
+            for line in format_attempt_logs(variant, result):
+                print(f"  {line}")
+        trusted_seed = current.get("trusted_seed", {})
+        if trusted_seed:
+            print(f"  trusted seed{format_metadata_log(trusted_seed)}")
+        for line in format_attempt_logs("trusted self", current.get("trusted_self", {})):
+            print(f"  {line}")
     elif failure is not None and not juice_only:
         reason = failure.get("reason", "unknown")
         print(f"本轮未测试待测端：{FAILURE_LABELS.get(reason, reason)}")
@@ -741,11 +770,15 @@ def main() -> int:
         raise SystemExit("缺少待测 API 的临时密钥环境变量")
     if not args.juice_only and not trusted_key:
         raise SystemExit("缺少可信 API 的临时密钥环境变量")
-    candidate = ResponsesClient(args.candidate_base_url, candidate_key, args.timeout)
+    candidate = ResponsesClient(
+        args.candidate_base_url, candidate_key, args.timeout, args.metadata_options
+    )
     trusted = (
         None
         if args.juice_only
-        else ResponsesClient(args.trusted_base_url, trusted_key, args.timeout)
+        else ResponsesClient(
+            args.trusted_base_url, trusted_key, args.timeout, args.metadata_options
+        )
     )
     trials: list[dict[str, Any]] = []
     candidate_attempts: list[dict[str, Any]] = []
@@ -910,7 +943,7 @@ def main() -> int:
                 output_literal_summary["status"]
             )
             report = {
-                "schema_version": 5,
+                "schema_version": 6,
                 "mode": (
                     "continuous_juice_only_v3_1_1_monitor"
                     if args.juice_only
@@ -920,6 +953,7 @@ def main() -> int:
                 "updated_at": report_time.isoformat(),
                 "trusted_source_health_reported_separately": True,
                 "configuration": {
+                    "request_metadata": args.metadata_options.report_config(),
                     "detection_mode": (
                         "juice_only" if args.juice_only else "combined"
                     ),

--- a/gpt56_reasoning_probe.py
+++ b/gpt56_reasoning_probe.py
@@ -21,6 +21,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from gpt56_juice_probe import (
     EFFORTS,
@@ -41,12 +42,24 @@ from gpt56_juice_probe import (
     summarize_output_literal_controls,
     summarize_juice,
 )
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock
 from typing import Any
 
 from gpt56_report_html import write_report_html
+from gpt56_request_metadata import (
+    MetadataOptions,
+    add_metadata_arguments,
+    build_request_metadata,
+    lookup_client_egress_ip,
+    format_metadata_log,
+    format_attempt_logs,
+    metadata_options_from_args,
+    resolve_server_ips,
+    utc_now,
+)
 
 
 TASKS = (
@@ -141,10 +154,17 @@ def transform(task: str, value: str) -> str:
 
 
 class ProbeError(RuntimeError):
-    def __init__(self, message: str, status: int | None = None, elapsed_ms: int | None = None):
+    def __init__(
+        self,
+        message: str,
+        status: int | None = None,
+        elapsed_ms: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
         super().__init__(message)
         self.status = status
         self.elapsed_ms = elapsed_ms
+        self.metadata = metadata or {}
 
 
 @dataclass
@@ -152,49 +172,151 @@ class ResponsesClient:
     base_url: str
     api_key: str
     timeout: float
+    metadata_options: MetadataOptions = field(default_factory=MetadataOptions)
+    _server_ips: list[str] = field(default_factory=list, init=False, repr=False)
+    _server_ips_loaded: bool = field(default=False, init=False, repr=False)
+    _client_ip: str | None = field(default=None, init=False, repr=False)
+    _client_ip_error: str | None = field(default=None, init=False, repr=False)
+    _client_ip_loaded: bool = field(default=False, init=False, repr=False)
+    _metadata_cache_lock: Lock = field(default_factory=Lock, init=False, repr=False)
 
     @property
     def url(self) -> str:
         return self.base_url.rstrip("/") + "/responses"
 
+    def _network_addresses(self) -> tuple[list[str], str | None, str | None]:
+        with self._metadata_cache_lock:
+            if self.metadata_options.include_server_ip and not self._server_ips_loaded:
+                self._server_ips = resolve_server_ips(self.url)
+                self._server_ips_loaded = True
+            if self.metadata_options.include_client_ip and not self._client_ip_loaded:
+                self._client_ip_loaded = True
+                try:
+                    self._client_ip = lookup_client_egress_ip(
+                        self.metadata_options.client_ip_lookup_url,
+                        timeout=min(max(self.timeout, 1.0), 10.0),
+                    )
+                except (OSError, ValueError) as exc:
+                    self._client_ip_error = type(exc).__name__
+        return self._server_ips, self._client_ip, self._client_ip_error
+
+    def _metadata(
+        self,
+        *,
+        correlation_id: str,
+        payload: dict[str, Any],
+        decoded: dict[str, Any],
+        response_headers: dict[str, str],
+        status: int | None,
+        started_at: datetime,
+        elapsed_ms: int,
+        response_size_bytes: int,
+    ) -> dict[str, Any]:
+        completed_at = utc_now()
+        server_ips, client_ip, client_ip_error = self._network_addresses()
+        return build_request_metadata(
+            options=self.metadata_options,
+            correlation_id=correlation_id,
+            url=self.url,
+            payload=payload,
+            response=decoded,
+            response_headers=response_headers,
+            status=status,
+            started_at=started_at,
+            completed_at=completed_at,
+            elapsed_ms=elapsed_ms,
+            response_size_bytes=response_size_bytes,
+            server_ips=server_ips,
+            client_ip=client_ip,
+            client_ip_error=client_ip_error,
+        )
+
     def post(self, payload: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
         body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        correlation_id = uuid.uuid4().hex
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": os.environ.get("GPT56_USER_AGENT", "python-urllib/3"),
+        }
+        if self.metadata_options.include_request_id:
+            headers["X-Client-Request-ID"] = correlation_id
         request = urllib.request.Request(
             self.url,
             data=body,
             method="POST",
-            headers={
-                "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-
-                "User-Agent": os.environ.get("GPT56_USER_AGENT", "python-urllib/3"),
-            },
+            headers=headers,
         )
+        started_at = utc_now()
         started = time.perf_counter()
         status: int | None = None
         raw = b""
+        response_headers: dict[str, str] = {}
         try:
             with urllib.request.urlopen(request, timeout=self.timeout) as response:
                 status = response.status
+                response_headers = dict(response.headers.items())
                 raw = response.read()
         except urllib.error.HTTPError as exc:
             status = exc.code
+            response_headers = dict(exc.headers.items()) if exc.headers else {}
             raw = exc.read()
         except Exception as exc:
             elapsed = round((time.perf_counter() - started) * 1000)
-            raise ProbeError(redact(str(exc)), status=None, elapsed_ms=elapsed) from exc
+            metadata = self._metadata(
+                correlation_id=correlation_id,
+                payload=payload,
+                decoded={},
+                response_headers=response_headers,
+                status=None,
+                started_at=started_at,
+                elapsed_ms=elapsed,
+                response_size_bytes=0,
+            )
+            raise ProbeError(
+                redact(str(exc)), status=None, elapsed_ms=elapsed, metadata=metadata
+            ) from exc
         elapsed = round((time.perf_counter() - started) * 1000)
         try:
             decoded = json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ProbeError("non-JSON response", status=status, elapsed_ms=elapsed) from exc
+            metadata = self._metadata(
+                correlation_id=correlation_id,
+                payload=payload,
+                decoded={},
+                response_headers=response_headers,
+                status=status,
+                started_at=started_at,
+                elapsed_ms=elapsed,
+                response_size_bytes=len(raw),
+            )
+            raise ProbeError(
+                "non-JSON response", status=status, elapsed_ms=elapsed, metadata=metadata
+            ) from exc
+        metadata = self._metadata(
+            correlation_id=correlation_id,
+            payload=payload,
+            decoded=decoded if isinstance(decoded, dict) else {},
+            response_headers=response_headers,
+            status=status,
+            started_at=started_at,
+            elapsed_ms=elapsed,
+            response_size_bytes=len(raw),
+        )
         if status is None or not 200 <= status < 300:
             error = decoded.get("error", decoded) if isinstance(decoded, dict) else decoded
-            raise ProbeError(str(redact(error)), status=status, elapsed_ms=elapsed)
+            raise ProbeError(
+                str(redact(error)), status=status, elapsed_ms=elapsed, metadata=metadata
+            )
         if not isinstance(decoded, dict):
-            raise ProbeError("response JSON is not an object", status=status, elapsed_ms=elapsed)
-        return decoded, {"http_status": status, "elapsed_ms": elapsed}
+            raise ProbeError(
+                "response JSON is not an object",
+                status=status,
+                elapsed_ms=elapsed,
+                metadata=metadata,
+            )
+        return decoded, metadata
 
 
 def seed_payload(model: str, prompt: str) -> dict[str, Any]:
@@ -303,11 +425,15 @@ def call_and_score(
             }
         except ProbeError as exc:
             last_error = exc
-            transport_errors.append({
-                "http_status": exc.status,
-                "elapsed_ms": exc.elapsed_ms,
+            error_event = {
                 "error": redact(str(exc)),
-            })
+                "request_metadata": exc.metadata,
+            }
+            if "http_status" in exc.metadata:
+                error_event["http_status"] = exc.metadata["http_status"]
+            if "elapsed_ms" in exc.metadata:
+                error_event["elapsed_ms"] = exc.metadata["elapsed_ms"]
+            transport_errors.append(error_event)
             transient = exc.status is None or exc.status in TRANSIENT_HTTP_STATUSES
             if transport_attempt >= max_transport_attempts or not transient:
                 break
@@ -319,11 +445,10 @@ def call_and_score(
         "status": "error",
         "exact": False,
         "plaintext_leak": False,
-        "http_status": last_error.status,
-        "elapsed_ms": last_error.elapsed_ms,
         "transport_attempts": transport_attempt,
         "transport_errors": transport_errors,
         "error": redact(str(last_error)),
+        **last_error.metadata,
     }
 
 def blind_guess_tail_probability(successes: int, trials: int) -> float:
@@ -415,6 +540,14 @@ def print_candidate_attempt_result(trial: dict[str, Any]) -> None:
         f"去掉编号后{'答对' if candidate['without_ids'].get('exact') else '未答对'}，"
         f"异常测试{'正常' if negative == 0 else '命中'}，线路{network}"
     )
+    for variant, result in candidate.items():
+        for line in format_attempt_logs(variant, result):
+            print(f"  {line}")
+    trusted_seed = trial.get("trusted_seed", {}).get("request_metadata", {})
+    if trusted_seed:
+        print(f"  trusted seed{format_metadata_log(trusted_seed)}")
+    for line in format_attempt_logs("trusted self", trial.get("trusted_self", {})):
+        print(f"  {line}")
 
 
 def print_probe_summary(report: dict[str, Any], report_path: Path) -> None:
@@ -557,6 +690,8 @@ def run_juice_batch(
         else:
             detail = "其他非数字回复（记为无证据）"
         print(f"  {index}/{len(jobs)} 结果：{detail}", flush=True)
+        for line in format_attempt_logs("request", observation):
+            print(f"    {line}", flush=True)
         return index, observation
 
     workers = min(args.workers, len(jobs))
@@ -600,6 +735,8 @@ def run_output_literal_control_once(
             f"返回 {observation.get('observed_text')!r}"
         )
     print(f"  结果：{detail}", flush=True)
+    for line in format_attempt_logs("request", observation):
+        print(f"  {line}", flush=True)
     return observation
 
 
@@ -625,6 +762,8 @@ def run_single_output_literal_controls(
         else:
             detail = f"返回 {observation.get('observed_text')!r}"
         print(f"  结果：{detail}", flush=True)
+        for line in format_attempt_logs("request", observation):
+            print(f"  {line}", flush=True)
     return observations
 
 
@@ -661,7 +800,7 @@ def run_juice_only_probe(
         "blind_guess_upper_tail_without_ids": None,
     }
     return {
-        "schema_version": 5,
+        "schema_version": 6,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "mode": "juice_only_single_v3_1_1",
         "verdict": "not_run_juice_only",
@@ -673,6 +812,7 @@ def run_juice_only_probe(
             "reasoning-state compatibility or prove backend identity."
         ),
         "configuration": {
+            "request_metadata": args.metadata_options.report_config(),
             "detection_mode": "juice_only",
             "candidate_base_url": args.candidate_base_url,
             "candidate_model": args.candidate_model,
@@ -743,6 +883,7 @@ def run_encrypted_attempt(
             "reason": "trusted_seed_error",
             "http_status": exc.status,
             "error": redact(str(exc)),
+            "request_metadata": exc.metadata,
         }
         print(f"COT 任务 {attempt} 舍弃：可信 API 生成状态失败。", flush=True)
         return attempt, None, rejection
@@ -803,8 +944,7 @@ def run_encrypted_attempt(
         "task": task,
         "expected_sha256": sha256(expected),
         "trusted_seed": {
-            "http_status": seed_meta["http_status"],
-            "elapsed_ms": seed_meta["elapsed_ms"],
+            "request_metadata": seed_meta,
             "output_item_types": [
                 item.get("type") for item in output if isinstance(item, dict)
             ],
@@ -826,10 +966,14 @@ def run_probe(args: argparse.Namespace) -> dict[str, Any]:
     if not candidate_key:
         raise SystemExit(f"缺少待测 API 临时密钥环境变量：{args.candidate_key_env}")
 
-    candidate = ResponsesClient(args.candidate_base_url, candidate_key, args.timeout)
+    candidate = ResponsesClient(
+        args.candidate_base_url, candidate_key, args.timeout, args.metadata_options
+    )
     if args.juice_only:
         return run_juice_only_probe(args, candidate)
-    trusted = ResponsesClient(args.trusted_base_url, trusted_key, args.timeout)
+    trusted = ResponsesClient(
+        args.trusted_base_url, trusted_key, args.timeout, args.metadata_options
+    )
     valid_trials: list[dict[str, Any]] = []
     rejected_attempts: list[dict[str, Any]] = []
     max_attempts = args.max_attempts or args.trials * 3
@@ -945,7 +1089,7 @@ def run_probe(args: argparse.Namespace) -> dict[str, Any]:
     )
 
     return {
-        "schema_version": 5,
+        "schema_version": 6,
         "mode": "combined_single_v3_1_1",
         "created_at": datetime.now(timezone.utc).isoformat(),
         "verdict": verdict,
@@ -957,6 +1101,7 @@ def run_probe(args: argparse.Namespace) -> dict[str, Any]:
             "This is not proof of physical backend identity and cannot distinguish Sol, Terra, or Luna."
         ),
         "configuration": {
+            "request_metadata": args.metadata_options.report_config(),
             "detection_mode": "combined" if not no_juice else "encrypted_only",
             "trusted_base_url": args.trusted_base_url,
             "trusted_model": args.trusted_model,
@@ -1156,8 +1301,10 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--timeout", type=float, default=180.0)
     parser.add_argument("--output", type=Path, default=Path("gpt56_probe_report.json"))
+    add_metadata_arguments(parser)
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
+    args.metadata_options = metadata_options_from_args(args)
     if args.self_test:
         return args
     if not args.candidate_base_url:

--- a/gpt56_report_html.py
+++ b/gpt56_report_html.py
@@ -87,6 +87,63 @@ def _alerts(report: dict[str, Any]) -> list[str]:
     return alerts
 
 
+def _iter_request_metadata(value: Any) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        if any(key in value for key in ("correlation_id", "server_request_id", "token_usage")):
+            found.append(value)
+        for child in value.values():
+            found.extend(_iter_request_metadata(child))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(_iter_request_metadata(child))
+    return found
+
+
+def _metadata_section(report: dict[str, Any]) -> str:
+    configuration = report.get("configuration", {})
+    options = configuration.get("request_metadata", {})
+    observations = _iter_request_metadata(report)[-30:]
+    rows: list[str] = []
+    for item in observations:
+        usage = item.get("token_usage") or {}
+        token_text = "-"
+        if isinstance(usage, dict):
+            source = "estimated" if usage.get("source") == "estimated" else "usage"
+            token_text = f"{source}: {_text(usage.get('total_tokens'))}"
+        request_id = (
+            item.get("server_request_id")
+            or item.get("response_id")
+            or item.get("correlation_id")
+        )
+        ip_text = item.get("client_egress_ip") or "-"
+        server_ips = item.get("server_ips") or []
+        if server_ips:
+            ip_text = f"{ip_text} / {', '.join(map(str, server_ips))}"
+        rows.append(
+            "<tr>"
+            f"<td>{_e(request_id)}</td><td>{_e(item.get('started_at'))}</td>"
+            f"<td>{_e(item.get('http_status'))}</td><td>{_e(item.get('elapsed_ms'))}</td>"
+            f"<td>{_e(token_text)}</td><td>{_e(ip_text)}</td>"
+            "</tr>"
+        )
+    if not rows:
+        rows.append('<tr><td colspan="6" class="muted">未收集到请求级元数据</td></tr>')
+    estimate_note = options.get("token_estimate_warning")
+    note = f"<p class=\"muted\">{_e(estimate_note)}</p>" if estimate_note else ""
+    enabled = ", ".join(
+        key for key, value in options.items() if key.startswith("include_") and value
+    ) or "仅默认安全字段"
+    return (
+        '<section class="band"><h2>请求级详细信息</h2>'
+        f"<p class=\"muted\">已启用：{_e(enabled)}</p>{note}"
+        '<table class="metadata-table"><thead><tr>'
+        "<th>Request ID</th><th>开始时间</th><th>HTTP</th><th>耗时(ms)</th>"
+        "<th>Token</th><th>客户端出口 IP / 服务端 DNS IP</th>"
+        f"</tr></thead><tbody>{''.join(rows)}</tbody></table></section>"
+    )
+
+
 def render_report_html(report: dict[str, Any]) -> str:
     combined = report.get("combined_summary", {})
     juice = report.get("juice_summary", {})
@@ -174,6 +231,7 @@ ul {{ margin:0; padding-left:20px; }} li {{ margin:5px 0; }} li.ok {{ color:var(
 .pill {{ display:inline-block; border:1px solid currentColor; border-radius:999px; padding:2px 8px; font-size:12px; }}
 .success-text {{ color:var(--success); }} .warning-text {{ color:var(--warning); }} .danger-text {{ color:var(--danger); }} .muted {{ color:var(--muted); }}
 .footer {{ color:var(--muted); font-size:12px; margin-top:18px; }}
+.metadata-table {{ font-size:12px; }}
 @media (max-width:720px) {{ .grid,.metrics {{ grid-template-columns:1fr; }} main {{ padding:14px; }} }}
 </style>
 </head>
@@ -220,6 +278,7 @@ ul {{ margin:0; padding-left:20px; }} li {{ margin:5px 0; }} li.ok {{ color:var(
   </div>
 </section>
 <p class="footer">加密状态层不能区分 Sol、Terra、Luna；Juice 与字面量输出对照均为可伪造的辅助证据。综合通过不能排除透明代理、探针识别或普通请求差异化路由。</p>
+{_metadata_section(report)}
 </main>
 </body>
 </html>"""

--- a/gpt56_request_metadata.py
+++ b/gpt56_request_metadata.py
@@ -1,0 +1,330 @@
+"""Privacy-aware request metadata collection for detector reports."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import ipaddress
+import json
+import math
+import socket
+from typing import Any, Mapping
+import urllib.request
+from urllib.parse import urlsplit
+
+
+DEFAULT_CLIENT_IP_LOOKUP_URL = "https://api64.ipify.org?format=json"
+REQUEST_ID_HEADERS = (
+    "x-request-id",
+    "request-id",
+    "openai-request-id",
+    "x-correlation-id",
+    "traceparent",
+    "cf-ray",
+)
+
+
+@dataclass(frozen=True)
+class MetadataOptions:
+    """Control which request details are persisted in reports."""
+
+    include_request_id: bool = True
+    include_timestamps: bool = True
+    include_duration: bool = True
+    include_http_status: bool = True
+    include_token_usage: bool = True
+    include_response_size: bool = True
+    include_server_ip: bool = False
+    include_client_ip: bool = False
+    estimate_tokens: bool = False
+    client_ip_lookup_url: str = DEFAULT_CLIENT_IP_LOOKUP_URL
+
+    def report_config(self) -> dict[str, Any]:
+        config = asdict(self)
+        config["client_ip_lookup_url"] = (
+            self.client_ip_lookup_url if self.include_client_ip else None
+        )
+        config["privacy_note"] = (
+            "IP fields are omitted unless explicitly enabled. Client egress IP lookup "
+            "uses the configured URL through the process proxy settings."
+        )
+        config["token_estimate_warning"] = (
+            "Estimated token counts are approximate and may differ from provider billing."
+            if self.estimate_tokens
+            else None
+        )
+        return config
+
+
+def add_metadata_arguments(parser: Any) -> None:
+    """Add consistent report-metadata options to an argparse parser."""
+
+    parser.add_argument("--omit-request-id", action="store_true")
+    parser.add_argument("--omit-timestamps", action="store_true")
+    parser.add_argument("--omit-duration", action="store_true")
+    parser.add_argument("--omit-http-status", action="store_true")
+    parser.add_argument("--omit-token-usage", action="store_true")
+    parser.add_argument("--omit-response-size", action="store_true")
+    parser.add_argument("--include-server-ip", action="store_true")
+    parser.add_argument("--include-client-ip", action="store_true")
+    parser.add_argument(
+        "--client-ip-lookup-url",
+        default=DEFAULT_CLIENT_IP_LOOKUP_URL,
+        help=(
+            "IP echo endpoint used only with --include-client-ip; the request follows "
+            "the process proxy settings so the observed address is the actual egress IP"
+        ),
+    )
+    parser.add_argument(
+        "--estimate-tokens",
+        action="store_true",
+        help=(
+            "estimate tokens only when provider usage is absent; estimates are approximate "
+            "and are clearly labelled in reports"
+        ),
+    )
+
+
+def metadata_options_from_args(args: Any) -> MetadataOptions:
+    return MetadataOptions(
+        include_request_id=not args.omit_request_id,
+        include_timestamps=not args.omit_timestamps,
+        include_duration=not args.omit_duration,
+        include_http_status=not args.omit_http_status,
+        include_token_usage=not args.omit_token_usage,
+        include_response_size=not args.omit_response_size,
+        include_server_ip=args.include_server_ip,
+        include_client_ip=args.include_client_ip,
+        estimate_tokens=args.estimate_tokens,
+        client_ip_lookup_url=args.client_ip_lookup_url,
+    )
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def resolve_server_ips(url: str) -> list[str]:
+    """Resolve the target hostname; these are DNS results, not proxy peer addresses."""
+
+    hostname = urlsplit(url).hostname
+    if not hostname:
+        return []
+    try:
+        return [str(ipaddress.ip_address(hostname))]
+    except ValueError:
+        pass
+    try:
+        addresses = {
+            item[4][0]
+            for item in socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+        }
+    except OSError:
+        return []
+    return sorted(addresses, key=lambda value: (":" in value, value))
+
+
+def lookup_client_egress_ip(url: str, timeout: float = 10.0) -> str:
+    """Query an IP echo service using urllib's normal proxy-aware transport."""
+
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json, text/plain",
+            "User-Agent": "gpt56-detector/metadata",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        raw = response.read(4096).decode("utf-8").strip()
+    candidate = raw
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        decoded = None
+    if isinstance(decoded, dict):
+        candidate = str(
+            decoded.get("ip") or decoded.get("origin") or decoded.get("query") or ""
+        ).split(",", 1)[0].strip()
+    return str(ipaddress.ip_address(candidate))
+
+
+def extract_request_id(headers: Mapping[str, str]) -> tuple[str | None, str | None]:
+    normalized = {str(key).casefold(): str(value) for key, value in headers.items()}
+    for name in REQUEST_ID_HEADERS:
+        value = normalized.get(name)
+        if value:
+            return value, name
+    return None, None
+
+
+def extract_usage(response: Mapping[str, Any]) -> dict[str, Any] | None:
+    usage = response.get("usage")
+    if not isinstance(usage, Mapping):
+        return None
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens"))
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens"))
+    total_tokens = usage.get("total_tokens")
+    result = {
+        "source": "provider_usage",
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+    details = {
+        key: value
+        for key, value in usage.items()
+        if key
+        not in {
+            "input_tokens",
+            "prompt_tokens",
+            "output_tokens",
+            "completion_tokens",
+            "total_tokens",
+        }
+    }
+    if details:
+        result["details"] = details
+    return result
+
+
+def _text_length(value: Any) -> int:
+    if isinstance(value, str):
+        return len(value)
+    if isinstance(value, Mapping):
+        if "content" in value:
+            return _text_length(value["content"])
+        ignored = {"role", "type", "id", "status"}
+        return sum(
+            _text_length(item) for key, item in value.items() if key not in ignored
+        )
+    if isinstance(value, (list, tuple)):
+        return sum(_text_length(item) for item in value)
+    return 0
+
+
+def estimate_usage(payload: Mapping[str, Any], response: Mapping[str, Any]) -> dict[str, Any]:
+    """Provide a deliberately labelled fallback when provider usage is unavailable."""
+
+    input_chars = _text_length(payload.get("input"))
+    output_chars = _text_length(response.get("output_text")) or _text_length(
+        response.get("output")
+    )
+    input_tokens = math.ceil(input_chars / 4) if input_chars else 0
+    output_tokens = math.ceil(output_chars / 4) if output_chars else 0
+    return {
+        "source": "estimated",
+        "method": "unicode_characters_divided_by_4",
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "warning": "Approximate only; tokenizer and provider billing may differ.",
+    }
+
+
+def build_request_metadata(
+    *,
+    options: MetadataOptions,
+    correlation_id: str,
+    url: str,
+    payload: Mapping[str, Any],
+    response: Mapping[str, Any],
+    response_headers: Mapping[str, str],
+    status: int | None,
+    started_at: datetime,
+    completed_at: datetime,
+    elapsed_ms: int,
+    response_size_bytes: int,
+    server_ips: list[str] | None = None,
+    client_ip: str | None = None,
+    client_ip_error: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if options.include_request_id:
+        request_id, request_id_header = extract_request_id(response_headers)
+        metadata.update(
+            {
+                "correlation_id": correlation_id,
+                "server_request_id": request_id,
+                "server_request_id_header": request_id_header,
+                "response_id": (
+                    response.get("id") if isinstance(response.get("id"), str) else None
+                ),
+            }
+        )
+    if options.include_timestamps:
+        metadata["started_at"] = started_at.isoformat()
+        metadata["completed_at"] = completed_at.isoformat()
+    if options.include_duration:
+        metadata["elapsed_ms"] = elapsed_ms
+    if options.include_http_status:
+        metadata["http_status"] = status
+    if options.include_response_size:
+        metadata["response_size_bytes"] = response_size_bytes
+    if options.include_token_usage:
+        usage = extract_usage(response)
+        if usage is None and options.estimate_tokens:
+            usage = estimate_usage(payload, response)
+        metadata["token_usage"] = usage
+    if options.include_server_ip:
+        metadata["server_ips"] = (
+            server_ips if server_ips is not None else resolve_server_ips(url)
+        )
+        metadata["server_ip_source"] = "target_hostname_dns_resolution"
+        metadata["server_ip_note"] = (
+            "These are target DNS results; when an HTTP proxy is used they are not the proxy peer IP."
+        )
+    if options.include_client_ip:
+        metadata["client_egress_ip"] = client_ip
+        metadata["client_ip_source"] = options.client_ip_lookup_url
+        if client_ip_error:
+            metadata["client_ip_error"] = client_ip_error
+    return metadata
+
+
+def format_metadata_log(metadata: Mapping[str, Any]) -> str:
+    """Render enabled metadata as a compact console-log suffix."""
+
+    parts: list[str] = []
+    request_id = (
+        metadata.get("server_request_id")
+        or metadata.get("response_id")
+        or metadata.get("correlation_id")
+    )
+    if request_id:
+        parts.append(f"request_id={request_id}")
+    if metadata.get("started_at"):
+        parts.append(f"time={metadata['started_at']}")
+    if "http_status" in metadata:
+        parts.append(f"http={metadata['http_status']}")
+    if "elapsed_ms" in metadata:
+        parts.append(f"elapsed_ms={metadata['elapsed_ms']}")
+    usage = metadata.get("token_usage")
+    if isinstance(usage, Mapping):
+        label = "estimated_tokens" if usage.get("source") == "estimated" else "tokens"
+        parts.append(f"{label}={usage.get('total_tokens')}")
+    if "response_size_bytes" in metadata:
+        parts.append(f"bytes={metadata['response_size_bytes']}")
+    if metadata.get("server_ips"):
+        parts.append(f"server_ip={metadata['server_ips'][0]}")
+    if metadata.get("client_egress_ip"):
+        parts.append(f"client_egress_ip={metadata['client_egress_ip']}")
+    return f" [{', '.join(parts)}]" if parts else ""
+
+
+def format_attempt_logs(label: str, result: Mapping[str, Any]) -> list[str]:
+    """Include retry attempts as separate lines before the final request."""
+
+    lines: list[str] = []
+    errors = result.get("transport_errors", [])
+    if isinstance(errors, list):
+        for index, error in enumerate(errors, start=1):
+            if not isinstance(error, Mapping):
+                continue
+            metadata = error.get("request_metadata", {})
+            suffix = format_metadata_log(metadata) if isinstance(metadata, Mapping) else ""
+            if suffix:
+                lines.append(f"{label} retry {index}{suffix}")
+    suffix = format_metadata_log(result)
+    if suffix:
+        lines.append(f"{label}{suffix}")
+    return lines

--- a/tests/test_request_metadata.py
+++ b/tests/test_request_metadata.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+from datetime import datetime, timezone
+
+from gpt56_request_metadata import (
+    MetadataOptions,
+    build_request_metadata,
+    estimate_usage,
+    extract_request_id,
+    extract_usage,
+    format_attempt_logs,
+    lookup_client_egress_ip,
+)
+from gpt56_juice_probe import run_juice_request
+from gpt56_reasoning_probe import ProbeError, ResponsesClient
+from gpt56_report_html import render_report_html
+
+
+class _Headers(dict):
+    def items(self):
+        return super().items()
+
+
+class _Response:
+    status = 200
+
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None):
+        self._body = body
+        self.headers = _Headers(headers or {})
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, *_args):
+        return self._body
+
+
+class RequestMetadataTests(unittest.TestCase):
+    def test_request_id_header_and_usage_are_normalized(self):
+        request_id, source = extract_request_id({"X-Request-ID": "srv-123"})
+        self.assertEqual((request_id, source), ("srv-123", "x-request-id"))
+        usage = extract_usage({"usage": {"input_tokens": 8, "output_tokens": 3, "total_tokens": 11}})
+        self.assertEqual(usage["total_tokens"], 11)
+        self.assertEqual(usage["source"], "provider_usage")
+
+    def test_sensitive_ip_fields_are_absent_by_default(self):
+        metadata = build_request_metadata(
+            options=MetadataOptions(),
+            correlation_id="local-1",
+            url="https://example.test/v1/responses",
+            payload={"input": [{"role": "user", "content": "hello"}]},
+            response={"usage": {"total_tokens": 2}},
+            response_headers={"x-request-id": "srv-1"},
+            status=200,
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            elapsed_ms=4,
+            response_size_bytes=20,
+        )
+        self.assertNotIn("server_ips", metadata)
+        self.assertNotIn("client_egress_ip", metadata)
+        self.assertEqual(metadata["server_request_id"], "srv-1")
+
+    def test_estimate_is_explicitly_labeled(self):
+        estimate = estimate_usage(
+            {"input": [{"role": "user", "content": "abcdefgh"}]},
+            {"output_text": "ijkl"},
+        )
+        self.assertEqual(estimate["source"], "estimated")
+        self.assertIn("Approximate", estimate["warning"])
+        self.assertEqual(estimate["total_tokens"], 3)
+
+    @patch("gpt56_request_metadata.urllib.request.urlopen")
+    def test_client_egress_lookup_accepts_json_ip(self, urlopen):
+        urlopen.return_value = _Response(json.dumps({"ip": "203.0.113.7"}).encode())
+        self.assertEqual(lookup_client_egress_ip("https://ip.test", timeout=1), "203.0.113.7")
+        urlopen.assert_called_once()
+
+    @patch("gpt56_reasoning_probe.urllib.request.urlopen")
+    def test_responses_client_records_metadata_and_sends_correlation_header(self, urlopen):
+        body = json.dumps(
+            {
+                "id": "resp-42",
+                "output_text": "READY",
+                "usage": {"input_tokens": 4, "output_tokens": 1, "total_tokens": 5},
+            }
+        ).encode()
+        urlopen.return_value = _Response(body, {"X-Request-ID": "server-42"})
+        client = ResponsesClient("https://api.test/v1", "secret", 3)
+        response, metadata = client.post({"model": "gpt-5.6-sol", "input": [{"content": "hi"}]})
+        self.assertEqual(response["output_text"], "READY")
+        self.assertEqual(metadata["server_request_id"], "server-42")
+        self.assertEqual(metadata["response_id"], "resp-42")
+        self.assertEqual(metadata["token_usage"]["total_tokens"], 5)
+        request = urlopen.call_args.args[0]
+        self.assertTrue(request.headers.get("X-client-request-id"))
+
+    @patch("gpt56_reasoning_probe.urllib.request.urlopen")
+    def test_all_optional_request_metadata_can_be_omitted(self, urlopen):
+        urlopen.return_value = _Response(b'{"output_text":"READY"}')
+        options = MetadataOptions(
+            include_request_id=False,
+            include_timestamps=False,
+            include_duration=False,
+            include_http_status=False,
+            include_token_usage=False,
+            include_response_size=False,
+        )
+        client = ResponsesClient("https://api.test/v1", "secret", 3, options)
+        _response, metadata = client.post({"input": "hi"})
+        self.assertEqual(metadata, {})
+        request = urlopen.call_args.args[0]
+        self.assertIsNone(request.headers.get("X-client-request-id"))
+
+    @patch("gpt56_juice_probe.time.sleep")
+    def test_retry_keeps_metadata_for_each_failed_network_attempt(self, _sleep):
+        class RetryingClient:
+            calls = 0
+
+            def post(self, _payload):
+                self.calls += 1
+                if self.calls == 1:
+                    raise ProbeError(
+                        "temporary",
+                        status=503,
+                        metadata={"correlation_id": "retry-1", "http_status": 503},
+                    )
+                return (
+                    {"output_text": "40", "id": "resp-success"},
+                    {"correlation_id": "retry-2", "response_id": "resp-success"},
+                )
+
+        result = run_juice_request(RetryingClient(), "gpt-5.6-sol", "high")
+        self.assertEqual(result["transport_attempts"], 2)
+        self.assertEqual(
+            result["transport_errors"][0]["request_metadata"]["correlation_id"],
+            "retry-1",
+        )
+        self.assertEqual(result["correlation_id"], "retry-2")
+        self.assertEqual(len(format_attempt_logs("request", result)), 2)
+
+    def test_html_report_includes_request_metadata(self):
+        report = {
+            "mode": "juice_only_single_v3_1_1",
+            "configuration": {
+                "detection_mode": "juice_only",
+                "request_metadata": MetadataOptions().report_config(),
+            },
+            "juice_observations": [
+                {
+                    "correlation_id": "local-1",
+                    "server_request_id": "server-1",
+                    "started_at": "2026-08-07T01:02:03+00:00",
+                    "http_status": 200,
+                    "elapsed_ms": 12,
+                    "token_usage": {"source": "provider_usage", "total_tokens": 9},
+                }
+            ],
+        }
+        html = render_report_html(report)
+        self.assertIn("请求级详细信息", html)
+        self.assertIn("server-1", html)
+        self.assertIn("usage: 9", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds request-level observability to single probes and continuous monitoring while keeping sensitive fields opt-in.

Every detector HTTP attempt now carries a local correlation ID in `X-Client-Request-ID` and exposes a privacy-filtered metadata record in JSON, HTML, and console output.

## Why the Request ID is useful

The detector can issue many requests per run and may retry transient failures. A single final status is not enough to locate a problematic request.

For each attempt, the report records (when Request ID is enabled):

- `correlation_id`: generated locally before the network call and sent as `X-Client-Request-ID`. It still exists when the request times out or the provider does not return an ID, so a user can match detector output with gateway/proxy logs.
- `server_request_id` and `server_request_id_header`: extracted from common provider/gateway headers including `x-request-id`, `request-id`, `openai-request-id`, `x-correlation-id`, `traceparent`, and `cf-ray`.
- `response_id`: the Responses API JSON `id`, which is often the provider's most precise request/response locator.

Retry attempts are not collapsed: each failed attempt keeps its own metadata under `transport_errors[].request_metadata`. This lets an operator identify exactly which attempt failed, correlate it with upstream logs, and distinguish a provider error from a later successful retry.

## Metadata captured

Default-on fields:

- UTC start/completion timestamps and elapsed milliseconds;
- HTTP status;
- provider token usage (input/output/total, plus provider-specific usage details when present);
- response byte size;
- local/server/response request identifiers described above.

Opt-in fields:

- target server DNS results (`server_ips`);
- client egress IP (`client_egress_ip`);
- approximate token fallback when the provider omits `usage`.

The GUI exposes these as individual checkboxes under “报告包含信息”. The CLI exposes the equivalent `--include-*`, `--omit-*`, `--client-ip-lookup-url`, and `--estimate-tokens` options.

## Privacy and IP behavior

- IP fields are disabled by default.
- Server IP means target hostname DNS results. When an HTTP proxy is used, the report explicitly says these are not the proxy peer IP.
- Client egress IP is obtained only when explicitly enabled, through a configurable IP-echo endpoint using Python's normal proxy-aware transport. This is intended to observe the real proxy egress address rather than a local interface address. The result is cached per API client to avoid an extra lookup for every detector request.
- Authorization/API keys, raw headers, and raw encrypted reasoning content remain excluded/redacted.

## Token handling

Provider `usage` is authoritative. If the advanced estimate option is enabled and usage is absent, the report uses a clearly labelled Unicode-character approximation (`source=estimated`) and includes a warning that it may differ from the provider tokenizer and billing. The estimate is never presented as provider usage.

## Reporting and tests

- JSON schema version is incremented to 6 and includes the selected metadata configuration.
- HTML reports contain a request-level details table with the latest 30 metadata records.
- Console logs include the same enabled fields and retry records.
- Added unit tests cover ID/header extraction, provider usage normalization, privacy defaults, optional omission, egress-IP parsing, retry metadata retention, and HTML rendering.
- Validation completed locally with:
  - `python -m unittest discover -s tests -v` (8 tests passed)
  - Python bytecode compilation for all detector modules
  - existing `python gpt56_reasoning_probe.py --self-test`

## Scope

This PR intentionally focuses on request observability and configurable privacy. It does not change the detector's model verdict logic.