### PR TITLE
修复跨平台浮点误差导致的基准包加载失败

### DIFF
--- a/gpt56_vnext/benchmark.py
+++ b/gpt56_vnext/benchmark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import math
 import re
 from typing import Any
 
@@ -244,6 +245,22 @@ def build_package(project: dict, observations: dict, *, collection: dict | None 
     return package
 
 
+def _fitted_matches(expected: Any, actual: Any) -> bool:
+    """Allow platform rounding only in derived floats; keep structure exact."""
+    if type(expected) is not type(actual):
+        return False
+    if isinstance(expected, dict):
+        return expected.keys() == actual.keys() and all(
+            _fitted_matches(expected[key], actual[key]) for key in expected)
+    if isinstance(expected, list):
+        return len(expected) == len(actual) and all(
+            _fitted_matches(a, b) for a, b in zip(expected, actual))
+    if isinstance(expected, float):
+        return math.isfinite(expected) and math.isfinite(actual) and math.isclose(
+            expected, actual, rel_tol=1e-12, abs_tol=1e-15)
+    return expected == actual
+
+
 def load_package(value: dict | str | bytes) -> dict:
     if isinstance(value, (str, bytes)):
         if len(value if isinstance(value, bytes) else value.encode("utf-8")) > MAX_PACKAGE_BYTES:
@@ -254,6 +271,11 @@ def load_package(value: dict | str | bytes) -> dict:
     rebuilt = build_package(value, value.get("observations", {}), collection=value.get("collection"),
                             calibration=value.get("calibration"), validation=value.get("validation"),
                             _legacy=value.get("engine", {}).get("scoring_version") == "meow-fingerprint-v1")
+    if not _fitted_matches(rebuilt["fitted"], value.get("fitted")):
+        raise AppError("package_derived_data_mismatch")
+    # Preserve published numbers so package hashes and calibration bindings stay valid.
+    rebuilt["fitted"] = deepcopy(value["fitted"])
+    rebuilt["content_sha256"] = content_hash(rebuilt)
     if canonical_json(rebuilt) != canonical_json(value):
         raise AppError("package_derived_data_mismatch")
     return rebuilt

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from copy import deepcopy
 import json
+import math
 from pathlib import Path
 import sys
 import tempfile
@@ -51,6 +52,45 @@ class BenchmarkTests(unittest.TestCase):
         changed["content_sha256"] = content_hash(changed)
         with self.assertRaises(AppError):
             load_package(changed)
+
+    def test_package_rounding_preserves_published_values_and_hash(self):
+        package = build_package(*fixture())
+        pairs = package["fitted"]["cells"]["ab"]["pairwise_jsd"]
+        pairs["a|b"] = math.nextafter(pairs["a|b"], math.inf)
+        package["content_sha256"] = content_hash(package)
+        loaded = load_package(json.dumps(package))
+        self.assertEqual(loaded, package)
+        self.assertEqual(load_package(loaded), package)
+        loaded["fitted"]["cells"]["ab"]["pairwise_jsd"]["a|b"] = 0.0
+        self.assertNotEqual(loaded["fitted"], package["fitted"])
+
+    def test_package_rounding_does_not_bypass_hash_check(self):
+        package = build_package(*fixture())
+        pairs = package["fitted"]["cells"]["ab"]["pairwise_jsd"]
+        pairs["a|b"] = math.nextafter(pairs["a|b"], math.inf)
+        with self.assertRaisesRegex(AppError, "package_hash_mismatch"):
+            load_package(package)
+
+    def test_package_rounding_keeps_structure_and_counts_exact(self):
+        package = build_package(*fixture())
+        variants = []
+        for replacement in (101, 100.0, True):
+            changed = deepcopy(package)
+            changed["fitted"]["cells"]["ab"]["model_counts"]["a"]["a"] = replacement
+            variants.append(changed)
+        changed = deepcopy(package)
+        del changed["fitted"]["cells"]["ab"]["quality"]
+        variants.append(changed)
+        changed = deepcopy(package)
+        changed["fitted"]["models"].reverse()
+        variants.append(changed)
+        changed = deepcopy(package)
+        changed["unexpected_field"] = "must not be accepted"
+        variants.append(changed)
+        for index, changed in enumerate(variants):
+            changed["content_sha256"] = content_hash(changed)
+            with self.subTest(index=index), self.assertRaisesRegex(AppError, "package_derived_data_mismatch"):
+                load_package(changed)
 
     def test_bad_shapes_counts_and_models(self):
         project, observations = fixture()


### PR DESCRIPTION
内置基准包在 Windows 环境生成。Linux 重算部分 JSD 派生指标时出现约 1e-17 的浮点末位差异；load_package 要求重建后的 JSON 完全一致，因此拒绝有效基准包，并导致 CI 中 5 项测试报错。

本次最小修复只调整基准包加载校验：
- 仅对 fitted 中的有限浮点数允许严格的小误差（rel_tol=1e-12，abs_tol=1e-15）；结构、类型、整数及其他内容仍严格检查。
- 保留原始内容哈希校验，并在派生数据校验通过后保留发布包的 fitted 数值，保持包哈希和校准绑定不变。
- 增加回归测试，覆盖浮点末位差异、返回值独立性、哈希检查以及结构和计数校验；原有大幅篡改检测仍保留。

验证：Linux / Python 3.12 / NumPy 2.3.5 下，修复前复现相同的 5 项错误；修复后 68 项单元测试通过、3 项报告 URL 检查通过、6 项校准绑定检查通过，中文和英文 ZIP 构建成功。Windows 和 macOS 由本 PR 的 GitHub Actions 验证。

本 PR 不修改基准包、检测阈值或版本号。已有 Release ZIP 需另行重打包发布才能包含修复。